### PR TITLE
feat: clang-tidy / clang-format

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,9 @@
+common:clang_tidy --aspects @bazel_utilities//tools:clang_tidy.bzl%clang_tidy
+common:clang_tidy --output_groups=+report
+common:clang_tidy --spawn_strategy=local
+
+common:clang_format --aspects @bazel_utilities//tools:clang_format.bzl%clang_format
+common:clang_format --output_groups=+report
+common:clang_format --spawn_strategy=local
+
+common:tidy_format_error --aspects_parameters=enable_error=True

--- a/tools/.clang-format
+++ b/tools/.clang-format
@@ -1,0 +1,71 @@
+BasedOnStyle: LLVM
+
+Language: Cpp
+Standard: Cpp11
+
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+ColumnLimit: 180
+
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignConsecutiveBitFields: true
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignTrailingComments: true
+AlignAfterOpenBracket: true
+PointerAlignment: Left
+DerivePointerAlignment: false
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterTemplateKeyword: true
+
+IncludeCategories:
+  - Regex: '^<.*\.h>'
+    Priority: 1
+  - Regex: '^".*\.h"'
+    Priority: 2
+SortIncludes: true
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: false
+SortUsingDeclarations: false
+
+LambdaBodyIndentation: Signature
+NamespaceIndentation: All
+
+AccessModifierOffset: -4
+IndentCaseLabels: true
+IndentGotoLabels: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+AlwaysBreakTemplateDeclarations: Yes
+
+# PackConstructorInitializers: false
+BreakConstructorInitializers: BeforeComma
+
+FixNamespaceComments: false

--- a/tools/.clang-tidy
+++ b/tools/.clang-tidy
@@ -5,6 +5,8 @@ User: ''
 # TODO: check for -llvmlibc-implementation-in-namespace
 Checks: >
   *
+  -clang-diagnostic-builtin-macro-redefined
+  -clang-diagnostic-unknown-warning-option
   -llvm-header-guard
   -llvmlibc-restrict-system-libc-headers
   -llvmlibc-implementation-in-namespace
@@ -12,7 +14,9 @@ Checks: >
 
 HeaderFilterRegex: '.*'
 
-WarningsAsErrors: ''
+WarningsAsErrors: >
+  -clang-diagnostic-builtin-macro-redefined
+  -clang-diagnostic-unknown-warning-option
 
 CheckOptions:
   - key: readability-identifier-naming.NamespaceCase

--- a/tools/.clang-tidy
+++ b/tools/.clang-tidy
@@ -1,0 +1,60 @@
+---
+FormatStyle: none
+User: ''
+
+# TODO: check for -llvmlibc-implementation-in-namespace
+Checks: >
+  *
+  -llvm-header-guard
+  -llvmlibc-restrict-system-libc-headers
+  -llvmlibc-implementation-in-namespace
+  -misc-non-private-member-variables-in-classes
+
+HeaderFilterRegex: '.*'
+
+WarningsAsErrors: ''
+
+CheckOptions:
+  - key: readability-identifier-naming.NamespaceCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: CamelBack
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.PublicMemberCase
+    value: CamelBack
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.LocalConstantCase
+    value: camelBack
+  - key: readability-identifier-naming.ParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassEnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.FileCase
+    value: CamelCase
+  - key: readability-identifier-naming.MacroCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.NestedNamespaceCase
+    value: CamelCase
+  - key: readability-identifier-naming.NamespaceDirCase
+    value: CamelCase
+...

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,33 @@
+"""
+"""
+
+##############################
+######### clang_tidy #########
+##############################
+
+filegroup(
+    name = "call_wrapper",
+    srcs = [ "call_wrapper.sh" ],
+)
+
+filegroup(
+    name = "clang_tidy_config_default",
+    srcs = [".clang-tidy"],
+)
+
+label_flag(
+    name = "clang_tidy_config",
+    build_setting_default = ":clang_tidy_config_default",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "clang_tidy_executable_default",
+    srcs = [],  # default system clang-tidy
+)
+
+label_flag(
+    name = "clang_tidy_executable",
+    build_setting_default = ":clang_tidy_executable_default",
+    visibility = ["//visibility:public"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,14 +1,11 @@
 """
 """
 
-##############################
-######### clang_tidy #########
-##############################
+#########################
+######### clang #########
+#########################
 
-filegroup(
-    name = "call_wrapper",
-    srcs = [ "call_wrapper.sh" ],
-)
+### clang_tidy ###
 
 filegroup(
     name = "clang_tidy_config_default",
@@ -29,5 +26,30 @@ filegroup(
 label_flag(
     name = "clang_tidy_executable",
     build_setting_default = ":clang_tidy_executable_default",
+    visibility = ["//visibility:public"],
+)
+
+
+### clang_format ###
+
+filegroup(
+    name = "clang_format_config_default",
+    srcs = [".clang-format"],
+)
+
+label_flag(
+    name = "clang_format_config",
+    build_setting_default = ":clang_format_config_default",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "clang_format_executable_default",
+    srcs = [],  # default system clang-format
+)
+
+label_flag(
+    name = "clang_format_executable",
+    build_setting_default = ":clang_format_executable_default",
     visibility = ["//visibility:public"],
 )

--- a/tools/call_wrapper.sh
+++ b/tools/call_wrapper.sh
@@ -1,9 +1,0 @@
-
-REPORT_FILE=$1
-shift
-BINARY=$1
-shift
-
-touch $REPORT_FILE
-
-"$BINARY" $@

--- a/tools/call_wrapper.sh
+++ b/tools/call_wrapper.sh
@@ -1,0 +1,9 @@
+
+REPORT_FILE=$1
+shift
+BINARY=$1
+shift
+
+touch $REPORT_FILE
+
+"$BINARY" $@

--- a/tools/clang_format.bzl
+++ b/tools/clang_format.bzl
@@ -1,0 +1,91 @@
+"""
+This file define a rule to execute clang_format
+"""
+
+load("@bazel_utilities//tools:utils.bzl", "rule_files")
+
+def _execute_clang_format(ctx, file):
+
+    local_run = len(ctx.files._clang_format_executable) == 0
+
+    report_file = ctx.actions.declare_file("clang_format/" + file.path)
+    
+    args = ctx.actions.args()
+
+    args.add("--style=file:{}".format(ctx.file._clang_format_config.path))
+    args.add(file.path)
+
+    ctx.actions.run_shell(
+        mnemonic = "ClangFormat",
+        inputs = [ ctx.file._clang_format_config ],
+        outputs = [ report_file ],
+        tools = [] if local_run else [ ctx.files._clang_format_executable[0] ],
+        arguments = [args],
+        command = "{clang_format} $@ > {report_path}".format(
+            report_path = report_file.path,
+            clang_format = "clang-format" if local_run else ctx.files._clang_format_executable[0],
+        ),
+    )
+
+    fmt = "touch {diff_path} && diff {file} {report_path}"
+    diff_file = ctx.actions.declare_file("clang_format/" + file.path + ".diff")
+
+    if ctx.attr.report_to_file:
+        fmt += " > {diff_path}"
+
+    if ctx.attr.enable_error == False:
+        fmt += " ; exit 0"
+    
+    ctx.actions.run_shell(
+        mnemonic = "ClangFormatDiff",
+        inputs = [ report_file ],
+        outputs = [ diff_file ],
+        command = fmt.format(
+            file = file.path,
+            report_path = report_file.path,
+            diff_path = diff_file.path
+        ),
+    )
+
+    return [ report_file, diff_file ]
+
+def _clang_format_impl(target, ctx):
+    # Ignore if it's not a C/C++ target
+    if not CcInfo in target:
+        return []
+
+    # Ignore external targets
+    if target.label.workspace_root.startswith("external"):
+        return []
+
+    # Tag to disable aspect
+    ignore_tags = [ "no-clang_format" ]
+    for tag in ignore_tags:
+        if tag in ctx.rule.attr.tags:
+            return []
+
+    files = rule_files(ctx.rule)
+
+    report_files = []
+    for file in files:
+        report_files += _execute_clang_format(
+            ctx = ctx,
+            file = file,
+        )
+
+    return [
+        OutputGroupInfo(report = depset(direct = report_files)),
+    ]
+
+clang_format = aspect(
+    implementation = _clang_format_impl,
+    attrs = {
+        "report_to_file": attr.bool(default = False),
+        "enable_error": attr.bool(default = False),
+
+        "_clang_format_executable": attr.label(default = Label("@bazel_utilities//tools:clang_format_executable")),
+        "_clang_format_config": attr.label(allow_single_file = True, default = Label("@bazel_utilities//tools:clang_format_config")),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/tools/clang_tidy.bzl
+++ b/tools/clang_tidy.bzl
@@ -94,6 +94,8 @@ def _clang_tidy_impl(target, ctx):
 
     report_files = []
     for file in files:
+        if ctx.attr.skip_headers and file_extention_match(file, CC_HEADER):
+            continue
         report_files += _execute_clang_tidy(
             ctx = ctx,
             file = file,
@@ -111,6 +113,8 @@ clang_tidy = aspect(
         "report_to_file": attr.bool(default = False),
         "enable_error": attr.bool(default = False),
         "system_header_errors": attr.bool(default = False),
+
+        "skip_headers": attr.bool(default = False),
 
         "_clang_tidy_executable": attr.label(default = Label("@bazel_utilities//tools:clang_tidy_executable")),
         "_clang_tidy_config": attr.label(allow_single_file = True, default = Label("@bazel_utilities//tools:clang_tidy_config")),

--- a/tools/clang_tidy.bzl
+++ b/tools/clang_tidy.bzl
@@ -1,0 +1,119 @@
+"""
+This file define a rule to execute clang_tidy
+
+Inspired by: https://github.com/erenon/bazel_clang_tidy
+"""
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_utilities//tools:utils.bzl", "toolchain_flags", "rule_files", "file_extention_match", "C_ALLOWED_FILES_EXT", "CC_HEADER")
+
+COMPILER_FILTER_FLAGS = [
+    "-fno-canonical-system-headers",
+    "-fstack-usage",
+]
+
+TIDY_FORCE_FLAGS = [
+    "--checks=-clang-diagnostic-builtin-macro-redefined",
+    "--warnings-as-errors=-clang-diagnostic-builtin-macro-redefined",
+]
+
+def _execute_clang_tidy(ctx,
+        file,
+        compilation_context,
+        flags
+    ):
+
+    local_run = len(ctx.files._clang_tidy_executable) == 0
+
+    report_file = ctx.actions.declare_file(file.path + ".clang_tidy.yaml")
+    
+    args = ctx.actions.args()
+
+    args.add(report_file.path)
+    if (local_run):
+        args.add("clang-tidy")
+    else:
+        args.add(ctx.files._clang_tidy_executable[0])
+
+    # clang-tidy args
+    args.add("--config-file", ctx.file._clang_tidy_config.path)
+    args.add("--export-fixes", report_file.path)
+    args.add(file.path)
+    args.add_all(TIDY_FORCE_FLAGS)
+
+    # compiler args
+    args.add("--")
+    args.add_all(flags)
+
+    args.add_all(compilation_context.defines.to_list(), before_each = "-D")
+    args.add_all(compilation_context.local_defines.to_list(), before_each = "-D")
+    args.add_all(compilation_context.includes.to_list(), before_each = "-I")
+    args.add_all(compilation_context.framework_includes.to_list(), before_each = "-F")
+    args.add_all(compilation_context.quote_includes.to_list(), before_each = "-iquote")
+    args.add_all(compilation_context.system_includes.to_list(), before_each = "-isystem")
+
+    ctx.actions.run(
+        mnemonic = "ClangTidy",
+        inputs = [ ctx.file._clang_tidy_config ],
+        outputs = [ report_file ],
+        tools = [ ctx.file._call_wrapper ] + ([ctx.files._clang_tidy_executable[0] ] if local_run == False else []),
+        executable = ctx.file._call_wrapper,
+        arguments = [args],
+    )
+
+    return report_file
+
+def _safe_flags(flags):
+    # Some flags might be used by GCC, but not understood by Clang.
+    # Remove them here, to allow users to run clang_tidy, without having
+    # a clang toolchain configured (that would produce a good command line with --compiler clang)
+    return [flag for flag in flags if flag not in COMPILER_FILTER_FLAGS]
+
+def _clang_tidy_impl(target, ctx):
+    # Ignore if it's not a C/C++ target
+    if not CcInfo in target:
+        return []
+
+    # Ignore external targets
+    if target.label.workspace_root.startswith("external"):
+        return []
+
+    # Tag to disable aspect
+    ignore_tags = [ "no-clang_tidy" ]
+    for tag in ignore_tags:
+        if tag in ctx.rule.attr.tags:
+            return []
+
+    files = rule_files(ctx.rule)
+    compilation_context = target[CcInfo].compilation_context
+    rule_copts = ctx.rule.attr.copts if hasattr(ctx.rule.attr, "copts") else []
+    copts = _safe_flags(toolchain_flags(ctx, ACTION_NAMES.c_compile) + rule_copts) + [ "-xc" ]
+    cxxopts = _safe_flags(toolchain_flags(ctx, ACTION_NAMES.cpp_compile) + rule_copts) + [ "-xc++" ]
+
+    report_files = []
+    for file in files:
+        if file_extention_match(file, CC_HEADER) == False:
+            report_files.append(
+                _execute_clang_tidy(
+                    ctx = ctx,
+                    file = file,
+                    compilation_context = compilation_context,
+                    flags = cxxopts
+                )
+            )
+
+    return [
+        OutputGroupInfo(report = depset(direct = report_files)),
+    ]
+
+clang_tidy = aspect(
+    implementation = _clang_tidy_impl,
+    attrs = {
+        "_clang_tidy_executable": attr.label(default = Label("@bazel_utilities//tools:clang_tidy_executable")),
+        "_clang_tidy_config": attr.label(allow_single_file = True, default = Label("@bazel_utilities//tools:clang_tidy_config")),
+
+        "_call_wrapper": attr.label(allow_single_file = True, default = Label("@bazel_utilities//tools:call_wrapper")),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/tools/utils.bzl
+++ b/tools/utils.bzl
@@ -1,0 +1,80 @@
+"""
+Utils rules
+"""
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+# Inspired by: https://github.com/erenon/bazel_clang_tidy
+def toolchain_flags(ctx, action_name = ACTION_NAMES.cpp_compile):
+    """Return the flags associted to an action and the current C/C++ toolchain
+
+    Args:
+        ctx: ctx
+        action_name: the action_name to execute from the toolchain
+    Returns:
+        List of toolchains flags
+    """
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+    compile_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        user_compile_flags = ctx.fragments.cpp.cxxopts + ctx.fragments.cpp.copts,
+    )
+    flags = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = action_name,
+        variables = compile_variables,
+    )
+    return flags
+
+C_ALLOWED_FILES_EXT = [
+    ".c", ".C",
+    ".h", ".H",
+]
+CXX_ALLOWED_FILES_EXT = [
+    ".cc", ".cpp", ".cxx", ".c++",
+    ".hh", ".hpp", ".hxx", ".inc", ".inl",
+]
+CC_ALLOWED_FILES = C_ALLOWED_FILES_EXT + CXX_ALLOWED_FILES_EXT
+
+CC_HEADER = [
+    ".h", ".H", ".hh", ".hpp", ".hxx", ".inc", ".inl"
+]
+
+def file_extention_match(file, allowed_files):
+    """Returns True if the file type matches one of the permitted file extention
+    
+    Args:
+        file: file
+        allowed_files: list of all extentions allowed files
+    Returns:
+        True or False
+    """
+    for file_type in allowed_files:
+        if file.basename.endswith(file_type):
+            return True
+    return False
+
+def rule_files(rule, allowed_files = CC_ALLOWED_FILES):
+    """Return all files in the given rule
+
+    Args:
+        rule: the ctx.rule member
+        allowed_files: list of all extentions allowed files
+    Returns:
+        The list of all files
+    """
+
+    files = []
+    if hasattr(rule.attr, "srcs"):
+        for src in rule.attr.srcs:
+            files += [file for file in src.files.to_list() if file.is_source and file_extention_match(file, allowed_files)]
+    if hasattr(rule.attr, "hdrs"):
+        for hdr in rule.attr.hdrs:
+            files += [file for file in hdr.files.to_list() if file.is_source and file_extention_match(file, allowed_files)]
+    return files

--- a/tools/vscode.bzl
+++ b/tools/vscode.bzl
@@ -1,4 +1,6 @@
-""
+"""
+This file define VSCode rules to generate c_cpp_properties / tasks and launch settings files
+"""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
@@ -13,6 +15,10 @@ VSCodeFlagsInfo = provider("", fields = {
 })
 
 def _impl_vscode_flags(_target, ctx):
+    # Ignore if it's not a C/C++ target
+    if not CcInfo in target:
+        return []
+
     includes = []
     defines = []
     flags = []
@@ -24,10 +30,6 @@ def _impl_vscode_flags(_target, ctx):
 
     if hasattr(ctx.rule.attr, 'copts'):
         flags += ctx.rule.attr.copts
-    if hasattr(ctx.rule.attr, 'conlyopts'):
-        flags += ctx.rule.attr.conlyopts
-    if hasattr(ctx.rule.attr, 'cxxopts'):
-        flags += ctx.rule.attr.cxxopts
     if hasattr(ctx.rule.attr, 'linkopts'):
         flags += ctx.rule.attr.linkopts
 


### PR DESCRIPTION
Provide aspects to run clang-format and clang-tidy
Only local have been tested for now. But it should work by providing it's own binaries.
Add a default config file. Only the default file have been tested for now. But it should work by providing it's own config files.