### PR TITLE
fix: build for clang based compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bazel module for commons functions used to define repository rules for hermetics toolchains.
 You can see this modules used here:
-- [bazel_winlibs_mingw](https://github.com/0-Sacha/bazel_winlibs_mingw)
+- [bazel_winlibs](https://github.com/0-Sacha/bazel_winlibs)
 - [bazel_arm](https://github.com/0-Sacha/bazel_arm)
 - [bazel_stm32](https://github.com/0-Sacha/bazel_stm32)
 

--- a/toolchains/cc_toolchain_config.bzl
+++ b/toolchains/cc_toolchain_config.bzl
@@ -4,6 +4,8 @@ According to:
 https://bazel.build/docs/cc-toolchain-config-reference
 """
 
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+
 load("//toolchains:artifacts.bzl", "artifacts_patterns_unpack")
 load("//toolchains:tools_utils.bzl",
     "link_actions_to_tool",
@@ -15,9 +17,6 @@ load("//toolchains:tools_utils.bzl",
 # load("//toolchains:xflags.bzl", "xflags_unpack")
 
 load("//toolchains/toolchains_features:toolchains_features.bzl", "TOOLCHAINS_FEATURES")
-
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
-# load("//toolchains:actions_grp.bzl", "TOOLCHAIN_ACTIONS")
 
 def toolchains_tools_actions_config(toolchain_tools):
     """Tools action config
@@ -173,7 +172,7 @@ def _impl_cc_toolchain_config(ctx):
 
         compiler = ctx.attr.compiler_type,
  
-        features = TOOLCHAINS_FEATURES[ctx.attr.compiler_type](ctx),
+        features = TOOLCHAINS_FEATURES[ctx.attr.compiler_type](ctx, ctx.attr.compiler_type),
         action_configs = toolchains_tools_actions_config(toolchain_tools),
         tool_paths = toolchain_ctx_tool_paths(toolchain_paths),
 

--- a/toolchains/toolchains_features/toolchains_features.bzl
+++ b/toolchains/toolchains_features/toolchains_features.bzl
@@ -1,9 +1,9 @@
 """
 """
 
-load("//toolchains/toolchains_features:gcc_toolchain_features.bzl", "toolchains_tools_features_config_gcc")
+load("//toolchains/toolchains_features:gcc_like_toolchain_features.bzl", "toolchains_tools_features_config_gcc_like")
 
 TOOLCHAINS_FEATURES = {
-    "gcc": toolchains_tools_features_config_gcc,
-    "clang": toolchains_tools_features_config_gcc,
+    "gcc": toolchains_tools_features_config_gcc_like,
+    "clang": toolchains_tools_features_config_gcc_like,
 }


### PR DESCRIPTION
fix: build for clang based compiler:
- Remove `-fno-canonical-system-headers` flag for clang typed compiler

Default `dbg_copts` to `[ "-g", "-Og" ]`
Default `opt_copts` to `[ "-O2" ]`